### PR TITLE
Add 50KB body size limit for get_request_detail to prevent MCP context overflow

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ export class NetworkMonitorMCP {
           {
             name: 'get_request_detail',
             description:
-              'Get full details for a specific request by UUID. Returns complete request/response data with optional headers.',
+              'Get full details for a specific request by UUID. Returns complete request/response data with 50KB body limit and optional headers to prevent MCP context overflow.',
             inputSchema: {
               type: 'object',
               properties: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -364,7 +364,7 @@ export class NetworkMonitorMCP {
         };
       }
 
-      // Return request details (headers optional)
+      // Return request details (headers optional, body limited to 50KB)
       const requestCopy: any = { ...request };
 
       if (!options.include_headers) {
@@ -373,6 +373,23 @@ export class NetworkMonitorMCP {
           requestCopy.response = { ...requestCopy.response };
           requestCopy.response.headers = undefined;
         }
+      }
+
+      // Limit body sizes to 50KB to prevent MCP context overflow
+      const MAX_BODY_SIZE = 50 * 1024; // 50KB
+
+      if (requestCopy.body && requestCopy.body.length > MAX_BODY_SIZE) {
+        const originalSize = requestCopy.body.length;
+        requestCopy.body =
+          requestCopy.body.substring(0, MAX_BODY_SIZE) +
+          `\n... [truncated from ${originalSize} bytes]`;
+      }
+
+      if (requestCopy.response?.body && requestCopy.response.body.length > MAX_BODY_SIZE) {
+        const originalSize = requestCopy.response.body.length;
+        requestCopy.response.body =
+          requestCopy.response.body.substring(0, MAX_BODY_SIZE) +
+          `\n... [truncated from ${originalSize} bytes]`;
       }
 
       return {


### PR DESCRIPTION
## Summary
- Add 50KB body size limit for get_request_detail API to prevent MCP context overflow errors
- Large request/response bodies are truncated with clear size indication
- Prevents "response exceeds maximum allowed tokens" errors that occurred with 67KB+ responses

## Changes
- Added 50KB truncation logic in get_request_detail method
- Added truncation message with original size information
- Updated README.md documentation to reflect 50KB limits
- Updated tool descriptions for context safety

## Test plan
- [x] All existing tests pass (32/32)
- [x] Added 3 new tests for 50KB body limiting functionality
- [x] Verified truncation works for both request and response bodies
- [x] Manual testing with real network requests
- [x] MCP integration testing confirms no context overflow