### PR TITLE
Fix FIFO queue buffer management and response-stage filtering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -301,8 +301,8 @@ export class NetworkMonitorMCP {
           urlIncludePatterns: options.filter.url_include_patterns,
           methods: options.filter.methods,
         },
-        options.max_buffer_size,
-        this.pendingRequests
+        this.pendingRequests,
+        options.max_buffer_size
       );
       this.isMonitoring = true;
 
@@ -397,8 +397,8 @@ export class NetworkMonitorMCP {
         urlIncludePatterns: options.filter.url_include_patterns,
         methods: options.filter.methods,
       },
-      30, // Use default buffer size for filter updates
-      this.pendingRequests
+      this.pendingRequests,
+      30 // Use default buffer size for filter updates
     );
 
     const status: MonitorStatus = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export class NetworkMonitorMCP {
   private cdpWebSocketUrl: string | null = null;
   private cdpPort = 9222;
   private networkBuffer: NetworkRequest[] = [];
+  private pendingRequests = new Map<string, NetworkRequest>();
   private cdpWebSocket: WebSocket | null = null;
   private browserServer: any = null;
 
@@ -300,7 +301,8 @@ export class NetworkMonitorMCP {
           urlIncludePatterns: options.filter.url_include_patterns,
           methods: options.filter.methods,
         },
-        options.max_buffer_size
+        options.max_buffer_size,
+        this.pendingRequests
       );
       this.isMonitoring = true;
 
@@ -395,7 +397,8 @@ export class NetworkMonitorMCP {
         urlIncludePatterns: options.filter.url_include_patterns,
         methods: options.filter.methods,
       },
-      30 // Use default buffer size for filter updates
+      30, // Use default buffer size for filter updates
+      this.pendingRequests
     );
 
     const status: MonitorStatus = {


### PR DESCRIPTION
## Summary
- Fix FIFO queue buffer management using pending requests pattern
- Move content-type filtering to response stage for accurate MIME type detection  
- Remove redundant code and improve buffer persistence across page navigation

## Changes
- Added `pendingRequests` Map to temporarily store requests until response filtering
- Moved filtering from request stage to response stage where MIME types are available
- Proper FIFO behavior: oldest requests removed when buffer capacity exceeded
- Clean code without unnecessary if-else logic

## Test plan
- [x] Buffer maintains proper FIFO queue behavior 
- [x] Content-type filtering works correctly at response stage
- [x] Buffer size limits respected (30 default, 50 max)
- [x] Both request and response body previews displayed
- [x] Network requests persist across page navigation

Closes #24